### PR TITLE
Added Dockerfile to build backend and fixed some build exceptions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+### Build stage
+FROM eclipse-temurin:17-jdk-alpine AS build
+WORKDIR /app
+
+ARG SPRING_PROFILES_ACTIVE=production
+
+# Install bash
+RUN apk add --no-cache bash
+
+# Copy maven files
+COPY .mvn/ .mvn/
+COPY mvnw pom.xml ./
+# Make mvnw executable
+RUN chmod +x mvnw
+
+# Copy the source code
+COPY src/ ./src/
+
+# Build the application
+RUN ./mvnw package -DskipTests -Dspring.profiles.active=${SPRING_PROFILES_ACTIVE}
+
+
+### Runtime stage
+FROM eclipse-temurin:17-jre-alpine AS runtime
+WORKDIR /app
+ARG SPRING_PROFILES_ACTIVE=production
+ENV SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}
+
+COPY --from=build /app/target/*.jar app.jar
+
+EXPOSE 8080
+
+CMD ["java", "-jar", "app.jar"]

--- a/src/main/java/dia/ismd/validator/ConvertorController.java
+++ b/src/main/java/dia/ismd/validator/ConvertorController.java
@@ -1,10 +1,10 @@
 package dia.ismd.validator;
 
+import dia.ismd.common.exceptions.JsonExportException;
 import dia.ismd.common.exceptions.UnsupportedFormatException;
 import dia.ismd.validator.convertor.ConvertorService;
 import dia.ismd.validator.enums.FileFormat;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.configurationprocessor.json.JSONException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -99,7 +99,7 @@ public class ConvertorController {
     }
 
     private ResponseEntity<?> getResponseEntity(
-            @RequestParam(value = "output", defaultValue = "json") String output) throws JSONException {
+            @RequestParam(value = "output", defaultValue = "json") String output) throws JsonExportException {
         return switch (output.toLowerCase()) {
             case "json" -> {
                 String jsonOutput = convertorService.exportArchiToJson();

--- a/src/main/java/dia/ismd/validator/convertor/ConvertorEngine.java
+++ b/src/main/java/dia/ismd/validator/convertor/ConvertorEngine.java
@@ -2,9 +2,9 @@ package dia.ismd.validator.convertor;
 
 import dia.ismd.common.exceptions.ConversionException;
 import dia.ismd.common.exceptions.FileParsingException;
+import dia.ismd.common.exceptions.JsonExportException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.configurationprocessor.json.JSONException;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -22,7 +22,7 @@ class ConvertorEngine {
         archiConvertor.convert();
     }
 
-    public String exportToJson() throws JSONException {
+    public String exportToJson() throws JsonExportException {
         return archiConvertor.exportToJson();
     }
 

--- a/src/main/java/dia/ismd/validator/convertor/ConvertorService.java
+++ b/src/main/java/dia/ismd/validator/convertor/ConvertorService.java
@@ -2,14 +2,14 @@ package dia.ismd.validator.convertor;
 
 import dia.ismd.common.exceptions.ConversionException;
 import dia.ismd.common.exceptions.FileParsingException;
-import org.springframework.boot.configurationprocessor.json.JSONException;
+import dia.ismd.common.exceptions.JsonExportException;
 
 public interface ConvertorService {
     void parseArchiFromString(String value) throws FileParsingException;
 
     void convertArchi() throws ConversionException;
 
-    String exportArchiToJson() throws JSONException;
+    String exportArchiToJson() throws JsonExportException;
 
     String exportArchiToTurtle();
 }

--- a/src/main/java/dia/ismd/validator/convertor/ConvertorServiceImpl.java
+++ b/src/main/java/dia/ismd/validator/convertor/ConvertorServiceImpl.java
@@ -1,9 +1,9 @@
 package dia.ismd.validator.convertor;
 
 import dia.ismd.common.exceptions.FileParsingException;
+import dia.ismd.common.exceptions.JsonExportException;
 import lombok.RequiredArgsConstructor;
 import org.apache.jena.ontology.ConversionException;
-import org.springframework.boot.configurationprocessor.json.JSONException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,7 +23,7 @@ class ConvertorServiceImpl implements ConvertorService {
     }
 
     @Override
-    public String exportArchiToJson() throws JSONException {
+    public String exportArchiToJson() throws JsonExportException {
         return convertorEngine.exportToJson();
     }
 


### PR DESCRIPTION
development: Added Dockerfile to build backend and containerize it.
- added Dockerfile. To run and be able to access it, you need to map port when running it, -p 8080:8080 for example

bugfix: Fixed build with mvnw
- changed some Exceptions JSONException being imported from a build only library to instead use our JsonExportException. That fixed the build errors.