### PR TITLE
feat: Add workflows for CD

### DIFF
--- a/.github/workflows/trigger-deployment.yml
+++ b/.github/workflows/trigger-deployment.yml
@@ -90,7 +90,7 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             // Create a deployment record
-            const result = await github.rest.repos.createDeployment({
+            const result = await github.action_repository.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: context.sha,
@@ -111,7 +111,7 @@ jobs:
             core.setOutput('deployment_id', result.data.id);
             
             // Update deployment status to pending
-            await github.rest.repos.createDeploymentStatus({
+            await github.action_repository.repos.createDeploymentStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               deployment_id: result.data.id,
@@ -125,7 +125,7 @@ jobs:
           github-token: ${{ secrets.INFRA_REPO_TOKEN }}
           script: |
             // Trigger the deployment via repository_dispatch to the infrastructure repo
-            const result = await github.rest.repos.createDispatchEvent({
+            const result = await github.action_repository.repos.createDispatchEvent({
               owner: context.repo.owner,
               repo: '${{ env.INFRA_REPO }}'.split('/')[1],
               event_type: 'new-image-${{ steps.determine_params.outputs.environment }}',
@@ -133,15 +133,15 @@ jobs:
                 component: '${{ env.COMPONENT_NAME }}',
                 image_tag: '${{ steps.determine_params.outputs.image_tag }}',
                 source_repo: '${{ github.repository }}',
-                source_deployment_id: '${{ steps.create_deployment.outputs.deployment_id }}'
+                source_deployment_id: '${{ steps.create_deployment.outputs.result }}'
               }
             });
             
             console.log('Triggered deployment in infrastructure repository');
             
             // Update deployment status to in_progress
-            const deploymentId = parseInt('${{ steps.create_deployment.outputs.deployment_id }}');
-            await github.rest.repos.createDeploymentStatus({
+            const deploymentId = parseInt('${{ steps.create_deployment.outputs.result }}');
+            await github.action_repository.repos.createDeploymentStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               deployment_id: deploymentId,

--- a/.github/workflows/trigger-deployment.yml
+++ b/.github/workflows/trigger-deployment.yml
@@ -35,8 +35,8 @@ jobs:
   prepare-deployment:
     name: Prepare Deployment
     runs-on: ubuntu-latest
-    # Only run if the build workflow succeeded or this was manually triggered
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    # Only run if this is a workflow_dispatch or workflow_run event with successful conclusion
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
     
     steps:
       - name: Checkout code
@@ -102,7 +102,7 @@ jobs:
                 component: '${{ env.COMPONENT_NAME }}',
                 triggered_by: '${{ github.actor }}',
                 timestamp: new Date().toISOString(),
-                workflow_run_id: '${{ github.event.workflow_run.id || "" }}'
+                workflow_run_id: github.event.workflow_run ? github.event.workflow_run.id : ''
               },
               description: 'Deployment of ${{ env.COMPONENT_NAME }} image ${{ steps.determine_params.outputs.image_tag }} to ${{ steps.determine_params.outputs.environment }}'
             });

--- a/.github/workflows/trigger-deployment.yml
+++ b/.github/workflows/trigger-deployment.yml
@@ -1,0 +1,150 @@
+name: Trigger Deployment
+
+on:
+  # Triggered when a new image is published
+  workflow_run:
+    workflows: ["Build Docker on Main", "Build Docker on Dev"]
+    types:
+      - completed
+    branches:
+      - main
+      - dev
+  
+  # Manual trigger with environment and version selection
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        type: choice
+        options:
+          - dev
+          - test
+          - prod
+        default: 'dev'
+      version:
+        description: 'Image version to deploy (leave empty for latest)'
+        required: false
+        type: string
+
+env:
+  INFRA_REPO: ${{ github.repository_owner }}/infrastructure
+  COMPONENT_NAME: backend
+
+jobs:
+  prepare-deployment:
+    name: Prepare Deployment
+    runs-on: ubuntu-latest
+    # Only run if the build workflow succeeded or this was manually triggered
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Determine environment and version
+        id: determine_params
+        run: |
+          # For manual triggers, use the specified environment
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            ENVIRONMENT="${{ github.event.inputs.environment }}"
+            
+            # If version is specified, use it
+            if [ -n "${{ github.event.inputs.version }}" ]; then
+              IMAGE_TAG="${{ github.event.inputs.version }}"
+            else
+              # Otherwise get the latest version from pom.xml
+              IMAGE_TAG=$(grep -m 1 "<version>" pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+            fi
+          else
+            # For automated triggers, determine environment from branch
+            if [ "${{ github.event.workflow_run.head_branch }}" == "main" ]; then
+              ENVIRONMENT="test"
+            else
+              ENVIRONMENT="dev"
+            fi
+            
+            # Get the version from pom.xml
+            IMAGE_TAG=$(grep -m 1 "<version>" pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+            
+            # For dev branch, append the short SHA
+            if [ "${{ github.event.workflow_run.head_branch }}" == "dev" ]; then
+              SHORT_SHA=$(echo ${{ github.event.workflow_run.head_sha }} | cut -c1-7)
+              IMAGE_TAG="${IMAGE_TAG}-${SHORT_SHA}"
+            fi
+          fi
+          
+          echo "ENVIRONMENT=${ENVIRONMENT}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+          echo "Environment: ${ENVIRONMENT}"
+          echo "Image tag: ${IMAGE_TAG}"
+          
+          # Set outputs for later steps
+          echo "environment=${ENVIRONMENT}" >> $GITHUB_OUTPUT
+          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+      
+      - name: Create GitHub Deployment
+        id: create_deployment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            // Create a deployment record
+            const result = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              environment: '${{ steps.determine_params.outputs.environment }}',
+              auto_merge: false,
+              required_contexts: [],
+              payload: {
+                image_tag: '${{ steps.determine_params.outputs.image_tag }}',
+                component: '${{ env.COMPONENT_NAME }}',
+                triggered_by: '${{ github.actor }}',
+                timestamp: new Date().toISOString(),
+                workflow_run_id: '${{ github.event.workflow_run.id || "" }}'
+              },
+              description: 'Deployment of ${{ env.COMPONENT_NAME }} image ${{ steps.determine_params.outputs.image_tag }} to ${{ steps.determine_params.outputs.environment }}'
+            });
+            
+            // Set output for subsequent steps
+            core.setOutput('deployment_id', result.data.id);
+            
+            // Update deployment status to pending
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: result.data.id,
+              state: 'pending',
+              description: 'Preparing to deploy'
+            });
+      
+      - name: Trigger Infrastructure Deployment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.INFRA_REPO_TOKEN }}
+          script: |
+            // Trigger the deployment via repository_dispatch to the infrastructure repo
+            const result = await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: '${{ env.INFRA_REPO }}'.split('/')[1],
+              event_type: 'new-image-${{ steps.determine_params.outputs.environment }}',
+              client_payload: {
+                component: '${{ env.COMPONENT_NAME }}',
+                image_tag: '${{ steps.determine_params.outputs.image_tag }}',
+                source_repo: '${{ github.repository }}',
+                source_deployment_id: '${{ steps.create_deployment.outputs.deployment_id }}'
+              }
+            });
+            
+            console.log('Triggered deployment in infrastructure repository');
+            
+            // Update deployment status to in_progress
+            const deploymentId = parseInt('${{ steps.create_deployment.outputs.deployment_id }}');
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deploymentId,
+              state: 'in_progress',
+              description: 'Deployment triggered in infrastructure repository'
+            });

--- a/.github/workflows/trigger-deployment.yml
+++ b/.github/workflows/trigger-deployment.yml
@@ -3,12 +3,9 @@ name: Trigger Deployment
 on:
   # Triggered when a new image is published
   workflow_run:
-    workflows: ["Build Docker on Main", "Build Docker on Dev"]
-    types:
-      - completed
-    branches:
-      - main
-      - dev
+    workflows: [Build Docker on Main, Build Docker on Dev]
+    types: [completed]
+    branches: [main, dev]
   
   # Manual trigger with environment and version selection
   workflow_dispatch:
@@ -21,26 +18,38 @@ on:
           - dev
           - test
           - prod
-        default: 'dev'
+        default: dev
       version:
         description: 'Image version to deploy (leave empty for latest)'
         required: false
         type: string
 
+permissions:
+  contents: read
+  deployments: write
+  actions: read
+
 env:
-  INFRA_REPO: ${{ github.repository_owner }}/infrastructure
+  INFRA_REPO: ${{ github.repository_owner }}/ismd-infrastructure
   COMPONENT_NAME: backend
 
 jobs:
-  prepare-deployment:
-    name: Prepare Deployment
+  determine-params:
+    name: Determine Deployment Parameters
     runs-on: ubuntu-latest
     # Only run if this is a workflow_dispatch or workflow_run event with successful conclusion
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+    outputs:
+      environment: ${{ steps.determine_params.outputs.environment }}
+      image_tag: ${{ steps.determine_params.outputs.image_tag }}
+      workflow_run_id: ${{ steps.determine_params.outputs.workflow_run_id }}
+      ref: ${{ steps.determine_params.outputs.ref }}
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+        with:
+          ref: dev
       
       - name: Determine environment and version
         id: determine_params
@@ -48,6 +57,8 @@ jobs:
           # For manual triggers, use the specified environment
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             ENVIRONMENT="${{ github.event.inputs.environment }}"
+            # Normalize to uppercase for job routing
+            ENVIRONMENT="${ENVIRONMENT^^}"
             
             # If version is specified, use it
             if [ -n "${{ github.event.inputs.version }}" ]; then
@@ -56,12 +67,18 @@ jobs:
               # Otherwise get the latest version from pom.xml
               IMAGE_TAG=$(grep -m 1 "<version>" pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
             fi
+
+            # For manual DEV, append short SHA only when no explicit version was provided
+            if [ "$ENVIRONMENT" = "DEV" ] && [ -z "${{ github.event.inputs.version }}" ]; then
+              SHORT_SHA=${GITHUB_SHA:0:7}
+              IMAGE_TAG="${IMAGE_TAG}-${SHORT_SHA}"
+            fi
           else
             # For automated triggers, determine environment from branch
             if [ "${{ github.event.workflow_run.head_branch }}" == "main" ]; then
-              ENVIRONMENT="test"
+              ENVIRONMENT="TEST"
             else
-              ENVIRONMENT="dev"
+              ENVIRONMENT="DEV"
             fi
             
             # Get the version from pom.xml
@@ -69,82 +86,217 @@ jobs:
             
             # For dev branch, append the short SHA
             if [ "${{ github.event.workflow_run.head_branch }}" == "dev" ]; then
-              SHORT_SHA=$(echo ${{ github.event.workflow_run.head_sha }} | cut -c1-7)
+              SHORT_SHA=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
               IMAGE_TAG="${IMAGE_TAG}-${SHORT_SHA}"
             fi
+          fi
+
+          # Determine the correct ref for the deployment
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            REF="${{ github.event.workflow_run.head_sha }}"
+          else
+            REF="${GITHUB_SHA}"
+          fi
+
+          # Safe workflow_run_id extraction
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            WORKFLOW_RUN_ID="${{ github.event.workflow_run.id }}"
+          else
+            WORKFLOW_RUN_ID=""
           fi
           
           echo "ENVIRONMENT=${ENVIRONMENT}" >> $GITHUB_ENV
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
           echo "Environment: ${ENVIRONMENT}"
           echo "Image tag: ${IMAGE_TAG}"
+          echo "Ref: ${REF}"
+          echo "Workflow Run ID: ${WORKFLOW_RUN_ID}"
           
           # Set outputs for later steps
           echo "environment=${ENVIRONMENT}" >> $GITHUB_OUTPUT
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "workflow_run_id=${WORKFLOW_RUN_ID}" >> $GITHUB_OUTPUT
+          echo "ref=${REF}" >> $GITHUB_OUTPUT
+      
+  # Deploy to dev environment
+  deploy-to-dev:
+    name: Deploy to Dev
+    needs: determine-params
+    if: needs.determine-params.outputs.environment == 'DEV'
+    runs-on: ubuntu-latest
+    environment:
+      name: DEV
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
       
       - name: Create GitHub Deployment
         id: create_deployment
-        uses: actions/github-script@v7
+        uses: chrnorm/deployment-action@v2
         with:
-          github-token: ${{ github.token }}
-          script: |
-            // Create a deployment record
-            const result = await github.action_repository.repos.createDeployment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: context.sha,
-              environment: '${{ steps.determine_params.outputs.environment }}',
-              auto_merge: false,
-              required_contexts: [],
-              payload: {
-                image_tag: '${{ steps.determine_params.outputs.image_tag }}',
-                component: '${{ env.COMPONENT_NAME }}',
-                triggered_by: '${{ github.actor }}',
-                timestamp: new Date().toISOString(),
-                workflow_run_id: github.event.workflow_run ? github.event.workflow_run.id : ''
-              },
-              description: 'Deployment of ${{ env.COMPONENT_NAME }} image ${{ steps.determine_params.outputs.image_tag }} to ${{ steps.determine_params.outputs.environment }}'
-            });
-            
-            // Set output for subsequent steps
-            core.setOutput('deployment_id', result.data.id);
-            
-            // Update deployment status to pending
-            await github.action_repository.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: result.data.id,
-              state: 'pending',
-              description: 'Preparing to deploy'
-            });
+          token: ${{ github.token }}
+          environment: DEV
+          ref: ${{ needs.determine-params.outputs.ref }}
+          description: 'Deployment of ${{ env.COMPONENT_NAME }} image ${{ needs.determine-params.outputs.image_tag }} to DEV'
+          auto-merge: false
+          payload: |
+            {
+              "image_tag": "${{ needs.determine-params.outputs.image_tag }}",
+              "component": "${{ env.COMPONENT_NAME }}",
+              "triggered_by": "${{ github.actor }}",
+              "timestamp": "${{ github.event.repository.updated_at }}",
+              "workflow_run_id": "${{ needs.determine-params.outputs.workflow_run_id }}"
+            }
+
+      - name: Update Deployment Status
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
+          state: "pending"
+          description: "Preparing to deploy"
       
       - name: Trigger Infrastructure Deployment
-        uses: actions/github-script@v7
+        uses: peter-evans/repository-dispatch@v3
         with:
-          github-token: ${{ secrets.INFRA_REPO_TOKEN }}
-          script: |
-            // Trigger the deployment via repository_dispatch to the infrastructure repo
-            const result = await github.action_repository.repos.createDispatchEvent({
-              owner: context.repo.owner,
-              repo: '${{ env.INFRA_REPO }}'.split('/')[1],
-              event_type: 'new-image-${{ steps.determine_params.outputs.environment }}',
-              client_payload: {
-                component: '${{ env.COMPONENT_NAME }}',
-                image_tag: '${{ steps.determine_params.outputs.image_tag }}',
-                source_repo: '${{ github.repository }}',
-                source_deployment_id: '${{ steps.create_deployment.outputs.result }}'
-              }
-            });
-            
-            console.log('Triggered deployment in infrastructure repository');
-            
-            // Update deployment status to in_progress
-            const deploymentId = parseInt('${{ steps.create_deployment.outputs.result }}');
-            await github.action_repository.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: deploymentId,
-              state: 'in_progress',
-              description: 'Deployment triggered in infrastructure repository'
-            });
+          token: ${{ secrets.INFRA_REPO_TOKEN }}
+          repository: ${{ env.INFRA_REPO }}
+          event-type: new-image-dev
+          client-payload: |
+            {
+              "component": "${{ env.COMPONENT_NAME }}",
+              "image_tag": "${{ needs.determine-params.outputs.image_tag }}",
+              "source_repo": "${{ github.repository }}",
+              "source_deployment_id": "${{ steps.create_deployment.outputs.deployment_id }}"
+            }
+      
+      - name: Update Deployment Status
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
+          state: "in_progress"
+          description: "Deployment triggered in infrastructure repository"
+  
+  # Deploy to test environment
+  deploy-to-test:
+    name: Deploy to Test
+    needs: determine-params
+    if: needs.determine-params.outputs.environment == 'TEST'
+    runs-on: ubuntu-latest
+    environment:
+      name: TEST
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      
+      - name: Create GitHub Deployment
+        id: create_deployment
+        uses: chrnorm/deployment-action@v2
+        with:
+          token: ${{ github.token }}
+          environment: TEST
+          ref: ${{ needs.determine-params.outputs.ref }}
+          description: 'Deployment of ${{ env.COMPONENT_NAME }} image ${{ needs.determine-params.outputs.image_tag }} to TEST'
+          auto-merge: false
+          payload: |
+            {
+              "image_tag": "${{ needs.determine-params.outputs.image_tag }}",
+              "component": "${{ env.COMPONENT_NAME }}",
+              "triggered_by": "${{ github.actor }}",
+              "timestamp": "${{ github.event.repository.updated_at }}",
+              "workflow_run_id": "${{ needs.determine-params.outputs.workflow_run_id }}"
+            }
+
+      - name: Update Deployment Status
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
+          state: "pending"
+          description: "Preparing to deploy"
+      
+      - name: Trigger Infrastructure Deployment
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.INFRA_REPO_TOKEN }}
+          repository: ${{ env.INFRA_REPO }}
+          event-type: new-image-test
+          client-payload: |
+            {
+              "component": "${{ env.COMPONENT_NAME }}",
+              "image_tag": "${{ needs.determine-params.outputs.image_tag }}",
+              "source_repo": "${{ github.repository }}",
+              "source_deployment_id": "${{ steps.create_deployment.outputs.deployment_id }}"
+            }
+      
+      - name: Update Deployment Status
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
+          state: "in_progress"
+          description: "Deployment triggered in infrastructure repository"
+  
+  # Deploy to prod environment
+  deploy-to-prod:
+    name: Deploy to Production
+    needs: determine-params
+    if: needs.determine-params.outputs.environment == 'PROD'
+    runs-on: ubuntu-latest
+    environment:
+      name: PROD
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      
+      - name: Create GitHub Deployment
+        id: create_deployment
+        uses: chrnorm/deployment-action@v2
+        with:
+          token: ${{ github.token }}
+          environment: PROD
+          ref: ${{ needs.determine-params.outputs.ref }}
+          description: 'Deployment of ${{ env.COMPONENT_NAME }} image ${{ needs.determine-params.outputs.image_tag }} to PROD'
+          auto-merge: false
+          payload: |
+            {
+              "image_tag": "${{ needs.determine-params.outputs.image_tag }}",
+              "component": "${{ env.COMPONENT_NAME }}",
+              "triggered_by": "${{ github.actor }}",
+              "timestamp": "${{ github.event.repository.updated_at }}",
+              "workflow_run_id": "${{ needs.determine-params.outputs.workflow_run_id }}"
+            }
+
+      - name: Update Deployment Status
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
+          state: "pending"
+          description: "Preparing to deploy"
+      
+      - name: Trigger Infrastructure Deployment
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.INFRA_REPO_TOKEN }}
+          repository: ${{ env.INFRA_REPO }}
+          event-type: new-image-prod
+          client-payload: |
+            {
+              "component": "${{ env.COMPONENT_NAME }}",
+              "image_tag": "${{ needs.determine-params.outputs.image_tag }}",
+              "source_repo": "${{ github.repository }}",
+              "source_deployment_id": "${{ steps.create_deployment.outputs.deployment_id }}"
+            }
+      
+      - name: Update Deployment Status
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
+          state: "in_progress"
+          description: "Deployment triggered in infrastructure repository"


### PR DESCRIPTION
align deployment workflow with FE; use dev branch for version, safe ref/run id, and lowercase events
- workflows with automatic triggers of infra deployment workflows on push
- Checkout dev in determine-params to read pom.xml when triggered from main
- Derive IMAGE_TAG from pom.xml; append -<shortsha> for DEV (no explicit version)
- Compute and output safe workflow_run_id and ref; use in deployments
- Lowercase repository_dispatch event types to match infra (new-image-dev/test/prod)