### PR TITLE
ci: align deployment workflow with FE; use dev branch for version, safe ref/run id, and lowercase events

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,15 @@
+name: PR Workflow
+
+on:
+  pull_request:
+    paths:
+      - '**'
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  run-tests:
+    uses: ./.github/workflows/reusable-test.yml

--- a/.github/workflows/push-to-dev.yml
+++ b/.github/workflows/push-to-dev.yml
@@ -1,0 +1,106 @@
+name: Build Docker on Dev
+
+on:
+  push:
+    branches:
+      - dev
+    paths-ignore:
+      - '**/README.md'
+      - '**/.gitignore'
+      - '**/*.md'
+      - '**/.gitkeep'
+      - '**/LICENSE'
+      - '**/target/**'
+      - '**/.idea/**'
+      - '**/*.iml'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  run-tests:
+    uses: ./.github/workflows/reusable-test.yml
+    
+  check-version-bump:
+    runs-on: ubuntu-latest
+    outputs:
+      skip-build: ${{ steps.check-commit.outputs.skip-build }}
+    steps:
+      - name: Check for version bump commit
+        id: check-commit
+        run: |
+          if [[ "${{ github.event.head_commit.message }}" =~ (Release v|Bump version) ]]; then
+            echo "skip-build=true" >> $GITHUB_OUTPUT
+            echo "Skipping build: Version bump detected"
+          else
+            echo "skip-build=false" >> $GITHUB_OUTPUT
+          fi
+    
+  check-changes:
+    needs: check-version-bump
+    if: needs.check-version-bump.outputs.skip-build != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      build-validator: ${{ steps.check-files.outputs.build-validator }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 2  # Need previous commit for comparison
+      
+      - name: Check for file changes
+        id: check-files
+        run: |
+          # Get list of changed files
+          echo "Checking for changed files..."
+          git diff --name-only HEAD^ HEAD > changed_files.txt
+          cat changed_files.txt
+          
+          # Define files to ignore (blacklist)
+          IGNORE_FILES=('README.md' '*.md' '.gitignore' '.gitkeep' 'LICENSE' '*.iml')
+          
+          # Create a temporary file with all changes
+          cp changed_files.txt relevant_changes.txt
+          
+          # Filter out ignored files
+          for pattern in "${IGNORE_FILES[@]}"; do
+            grep -v "$pattern" relevant_changes.txt > temp && mv temp relevant_changes.txt || true
+          done
+          
+          # If no relevant files changed, skip builds
+          if [ ! -s relevant_changes.txt ]; then
+            echo "No relevant files changed, skipping builds"
+            echo "build-validator=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # Check for changes that require both modules to be rebuilt
+          if grep -q '^\.github/workflows/' relevant_changes.txt || grep -q '^pom\.xml$' relevant_changes.txt; then
+            echo "Workflow files or root POM changed, rebuilding validator module"
+            echo "build-validator=true" >> $GITHUB_OUTPUT
+          else
+            # Check for module-specific changes if no workflow changes
+            # Only rebuild validator if common module's POM changed (version change)
+            if grep -q '^ismd-backend-common/pom.xml' relevant_changes.txt; then
+              echo "Common module POM changed, need to rebuild validator"
+              echo "build-validator=true" >> $GITHUB_OUTPUT
+            fi
+            
+            if grep -q '^ismd-backend-validator/' relevant_changes.txt; then
+              echo "Validator module files changed"
+              echo "build-validator=true" >> $GITHUB_OUTPUT
+            else
+              echo "No validator module changes"
+              echo "build-validator=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+
+  # Build validator module if changed
+  build-validator:
+    needs: [run-tests, check-changes]
+    if: needs.check-changes.outputs.build-validator == 'true'
+    uses: ./.github/workflows/reusable-docker-build.yml
+    with:
+      branch: dev
+      module: validator

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -1,0 +1,66 @@
+name: Build Docker on Main
+
+on:
+  push:
+    branches:
+      - main
+    # Blacklist approach - ignore these paths
+    paths-ignore:
+      - '**/README.md'
+      - '**/.gitignore'
+      - '**/*.md'
+      - '**/.gitkeep'
+      - '**/LICENSE'
+      - '**/target/**'
+      - '**/.idea/**'
+      - '**/*.iml'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # Build Docker image for main branch
+  build-validator:
+    uses: ./.github/workflows/reusable-docker-build.yml
+    with:
+      branch: main
+      module: validator
+      
+  # Sync dev with main after Docker build
+  sync-dev:
+    needs: build-validator
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Get full history
+      
+      - name: Set up SSH agent
+        uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+      
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin git@github.com:${{ github.repository }}.git
+      
+      - name: Recreate dev from main
+        run: |
+          # Get the current main branch
+          git fetch origin main
+          
+          # Create a temporary branch from main
+          git checkout main
+          git checkout -b temp-dev
+          
+          # Force push this branch to dev
+          echo "Recreating dev from main..."
+          git push --force origin temp-dev:dev
+          
+          echo "Dev branch has been recreated from main"

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -1,0 +1,166 @@
+name: Release Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 1.3.0 for minor release, 2.0.0 for major; leave empty for auto-patch-increment)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      current_version: ${{ steps.current-version.outputs.version }}
+      main_version: ${{ steps.main-version.outputs.version }}
+      new_version: ${{ steps.new-version.outputs.version }}
+    steps:
+      - name: Checkout dev branch
+        uses: actions/checkout@v5
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Fetch main branch
+        run: git fetch origin main:main
+
+      - name: Get current version in dev
+        id: current-version
+        run: echo "version=$(./mvnw help:evaluate -DforceStdout -q -Dexpression=project.version)" >> $GITHUB_OUTPUT
+
+      - name: Get version in main
+        id: main-version
+        run: |
+          # Get main branch version by directly parsing the output of git show
+          ARTIFACT_ID=$(./mvnw help:evaluate -DforceStdout -q -Dexpression=project.artifactId)
+          MAIN_VERSION=$(git show main:pom.xml | grep -A 10 "<artifactId>$ARTIFACT_ID</artifactId>" | grep '<version>' | head -1 | sed -E 's/.*<version>([^<]+)<.*/\1/')
+          echo "version=$MAIN_VERSION" >> $GITHUB_OUTPUT
+          echo "Main branch version: $MAIN_VERSION"
+
+      - name: Determine new version
+        id: new-version
+        run: |
+          CURRENT_VERSION="${{ steps.current-version.outputs.version }}"
+          MAIN_VERSION="${{ steps.main-version.outputs.version }}"
+          
+          # Check if user provided a version
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            # User-provided version takes precedence
+            NEW_VERSION="${{ github.event.inputs.version }}"
+            echo "User provided version: $NEW_VERSION"
+          else
+            # Check if version in dev already differs from main
+            if [ "$CURRENT_VERSION" != "$MAIN_VERSION" ]; then
+              # Version already changed in code, use as is
+              NEW_VERSION="$CURRENT_VERSION"
+              echo "Using existing version from code: $NEW_VERSION"
+            else
+              # Auto-increment patch version
+              NEW_VERSION=$(echo $CURRENT_VERSION | awk -F. -v OFS=. '{$NF++;print}')
+              echo "Auto-incremented version: $NEW_VERSION"
+            fi
+          fi
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create release branch
+        id: create-branch
+        run: |
+          BRANCH_NAME="release-v${{ steps.new-version.outputs.version }}"
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          
+          # Make sure we're on dev branch
+          git checkout dev
+          
+          # Create a new branch from dev
+          git checkout -b $BRANCH_NAME
+          
+          # Check if the version needs to be updated
+          CURRENT_VERSION="${{ steps.current-version.outputs.version }}"
+          NEW_VERSION="${{ steps.new-version.outputs.version }}"
+          
+          if [ "$CURRENT_VERSION" != "$NEW_VERSION" ]; then
+            echo "Updating version from $CURRENT_VERSION to $NEW_VERSION"
+            # Update version in root POM and all modules
+            ./mvnw versions:set -DnewVersion="$NEW_VERSION" -DgenerateBackupPoms=false -DprocessAllModules=true
+          
+            # Configure git
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+            # Stage all POM files (root and modules)
+            git add pom.xml ismd-backend-common/pom.xml ismd-backend-validator/pom.xml
+            git commit -m "Release v$NEW_VERSION"
+            echo "Version updated and committed"
+          else
+            echo "Version is already $CURRENT_VERSION, no update needed"
+            # Configure git anyway for later steps
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+          fi
+
+      - name: Run tests
+        run: |
+          # Build and run tests to ensure the release is stable
+          ./mvnw clean test
+
+      - name: Push release branch
+        run: |
+          # Only push if tests pass
+          git push origin ${{ steps.create-branch.outputs.branch_name }}
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Check if PR already exists
+          BRANCH_NAME="${{ steps.create-branch.outputs.branch_name }}"
+          PR_EXISTS=$(gh pr list --head $BRANCH_NAME --base main --json number --jq 'length')
+          
+          if [ "$PR_EXISTS" = "0" ]; then
+            # Create new PR
+            gh pr create \
+              --title "Release v${{ steps.new-version.outputs.version }}" \
+              --body "# Release v${{ steps.new-version.outputs.version }}
+          
+              This PR updates the version from v${{ steps.current-version.outputs.version }} to v${{ steps.new-version.outputs.version }} and merges changes from dev into main.
+          
+              ## Changes included:
+              - Version bump to v${{ steps.new-version.outputs.version }}
+              - All changes from dev branch
+          
+              Once merged, this will trigger a Docker build with the new version." \
+              --base main \
+              --head $BRANCH_NAME
+          
+            echo "Created new PR from $BRANCH_NAME to main"
+          else
+            # PR already exists, just update the description
+            PR_NUMBER=$(gh pr list --head $BRANCH_NAME --base main --json number --jq '.[0].number')
+          
+            gh pr edit $PR_NUMBER \
+              --title "Release v${{ steps.new-version.outputs.version }}" \
+              --body "# Release v${{ steps.new-version.outputs.version }}
+          
+              This PR updates the version from v${{ steps.current-version.outputs.version }} to v${{ steps.new-version.outputs.version }} and merges changes from dev into main.
+          
+              ## Changes included:
+              - Version bump to v${{ steps.new-version.outputs.version }}
+              - All changes from dev branch
+          
+              Once merged, this will trigger a Docker build with the new version.
+          
+              *Updated on $(date)*"
+          
+            echo "Updated existing PR #$PR_NUMBER"
+          fi

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -1,0 +1,116 @@
+name: Reusable Docker Build Workflow
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Branch name (main or dev)'
+        required: true
+        type: string
+      module:
+        description: 'Module to build (common, validator, or empty for all)'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with: 
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up repository path
+        id: repo-setup
+        run: |
+          # Convert repository name to lowercase and set as base path
+          REPO_PATH=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          
+          # Append branch suffix for non-main branches
+          if [ "${{ inputs.branch }}" != "main" ]; then
+            REPO_PATH="${REPO_PATH}-${{ inputs.branch }}"
+          fi
+          
+          echo "REPO_PATH=${REPO_PATH}" >> $GITHUB_ENV
+
+      - name: Get version info
+        id: version
+        run: |
+          # Get the base version from Maven
+          if [ -z "${{ inputs.module }}" ] || [ "${{ inputs.module }}" = "root" ]; then
+            BASE_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          else
+            BASE_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout -pl ismd-backend-${{ inputs.module }})
+          fi
+          
+          # For dev branches, create a version with Git SHA
+          if [ "${{ inputs.branch }}" != "main" ]; then
+            GIT_SHA=$(git rev-parse --short HEAD)
+            VERSION="${BASE_VERSION}-${GIT_SHA}"
+          else
+            VERSION="${BASE_VERSION}"
+            GIT_SHA=""
+          fi
+          
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "base_version=$BASE_VERSION" >> $GITHUB_OUTPUT
+          echo "git_sha=$GIT_SHA" >> $GITHUB_OUTPUT
+          
+          echo "Using version: $VERSION (base: $BASE_VERSION, git: $GIT_SHA)"
+
+      - name: Build and push Docker images
+        run: |
+          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          
+          # Determine which modules to build
+          if [ -z "${{ inputs.module }}" ]; then
+            # Build only the validator module as common is just a library
+            MODULES=("validator")
+            MODULE_ARG="."  # Build everything
+          else
+            # Build specific module
+            MODULES=("${{ inputs.module }}")
+            MODULE_ARG="ismd-backend-${{ inputs.module }}"
+          fi
+          
+          # Build and push each module
+          for MODULE in "${MODULES[@]}"; do
+            echo "Building module: $MODULE"
+            
+            # Use the precomputed repository path
+            IMAGE_TAG="ghcr.io/${{ env.REPO_PATH }}:${{ steps.version.outputs.version }}"
+            LATEST_TAG="ghcr.io/${{ env.REPO_PATH }}:latest"
+            
+            echo "Building $MODULE with tags:"
+            echo "  - $IMAGE_TAG"
+            echo "  - $LATEST_TAG"
+            
+            # Build and push the image using the root Dockerfile
+            docker build \
+              --target ${MODULE}-runtime \
+              --build-arg MODULE="${MODULE_ARG}" \
+              --build-arg MODULE_VERSION="${{ steps.version.outputs.version }}" \
+              --build-arg GIT_COMMIT="${{ steps.version.outputs.git_sha }}" \
+              -t $IMAGE_TAG \
+              ${LATEST_TAG:+-t $LATEST_TAG} \
+              .
+            
+            # Push the built image
+            docker push $IMAGE_TAG
+            
+            # Push both version and latest tags
+            docker push $LATEST_TAG
+            
+            echo "Successfully pushed $IMAGE_TAG"
+            echo "Successfully pushed $LATEST_TAG"
+          done

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -1,0 +1,31 @@
+name: Reusable Test Workflow
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build with Maven
+        run: ./mvnw clean package -DskipTests=true
+
+      - name: Run tests
+        run: ./mvnw test

--- a/.github/workflows/trigger-deployment.yml
+++ b/.github/workflows/trigger-deployment.yml
@@ -1,0 +1,302 @@
+name: Trigger Deployment
+
+on:
+  # Triggered when a new image is published
+  workflow_run:
+    workflows: [Build Docker on Main, Build Docker on Dev]
+    types: [completed]
+    branches: [main, dev]
+  
+  # Manual trigger with environment and version selection
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        type: choice
+        options:
+          - dev
+          - test
+          - prod
+        default: dev
+      version:
+        description: 'Image version to deploy (leave empty for latest)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  deployments: write
+  actions: read
+
+env:
+  INFRA_REPO: ${{ github.repository_owner }}/ismd-infrastructure
+  COMPONENT_NAME: backend
+
+jobs:
+  determine-params:
+    name: Determine Deployment Parameters
+    runs-on: ubuntu-latest
+    # Only run if this is a workflow_dispatch or workflow_run event with successful conclusion
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+    outputs:
+      environment: ${{ steps.determine_params.outputs.environment }}
+      image_tag: ${{ steps.determine_params.outputs.image_tag }}
+      workflow_run_id: ${{ steps.determine_params.outputs.workflow_run_id }}
+      ref: ${{ steps.determine_params.outputs.ref }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: dev
+      
+      - name: Determine environment and version
+        id: determine_params
+        run: |
+          # For manual triggers, use the specified environment
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            ENVIRONMENT="${{ github.event.inputs.environment }}"
+            # Normalize to uppercase for job routing
+            ENVIRONMENT="${ENVIRONMENT^^}"
+            
+            # If version is specified, use it
+            if [ -n "${{ github.event.inputs.version }}" ]; then
+              IMAGE_TAG="${{ github.event.inputs.version }}"
+            else
+              # Otherwise get the latest version from pom.xml
+              IMAGE_TAG=$(grep -m 1 "<version>" pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+            fi
+
+            # For manual DEV, append short SHA only when no explicit version was provided
+            if [ "$ENVIRONMENT" = "DEV" ] && [ -z "${{ github.event.inputs.version }}" ]; then
+              SHORT_SHA=${GITHUB_SHA:0:7}
+              IMAGE_TAG="${IMAGE_TAG}-${SHORT_SHA}"
+            fi
+          else
+            # For automated triggers, determine environment from branch
+            if [ "${{ github.event.workflow_run.head_branch }}" == "main" ]; then
+              ENVIRONMENT="TEST"
+            else
+              ENVIRONMENT="DEV"
+            fi
+            
+            # Get the version from pom.xml
+            IMAGE_TAG=$(grep -m 1 "<version>" pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+            
+            # For dev branch, append the short SHA
+            if [ "${{ github.event.workflow_run.head_branch }}" == "dev" ]; then
+              SHORT_SHA=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
+              IMAGE_TAG="${IMAGE_TAG}-${SHORT_SHA}"
+            fi
+          fi
+
+          # Determine the correct ref for the deployment
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            REF="${{ github.event.workflow_run.head_sha }}"
+          else
+            REF="${GITHUB_SHA}"
+          fi
+
+          # Safe workflow_run_id extraction
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            WORKFLOW_RUN_ID="${{ github.event.workflow_run.id }}"
+          else
+            WORKFLOW_RUN_ID=""
+          fi
+          
+          echo "ENVIRONMENT=${ENVIRONMENT}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+          echo "Environment: ${ENVIRONMENT}"
+          echo "Image tag: ${IMAGE_TAG}"
+          echo "Ref: ${REF}"
+          echo "Workflow Run ID: ${WORKFLOW_RUN_ID}"
+          
+          # Set outputs for later steps
+          echo "environment=${ENVIRONMENT}" >> $GITHUB_OUTPUT
+          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "workflow_run_id=${WORKFLOW_RUN_ID}" >> $GITHUB_OUTPUT
+          echo "ref=${REF}" >> $GITHUB_OUTPUT
+      
+  # Deploy to dev environment
+  deploy-to-dev:
+    name: Deploy to Dev
+    needs: determine-params
+    if: needs.determine-params.outputs.environment == 'DEV'
+    runs-on: ubuntu-latest
+    environment:
+      name: DEV
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      
+      - name: Create GitHub Deployment
+        id: create_deployment
+        uses: chrnorm/deployment-action@v2
+        with:
+          token: ${{ github.token }}
+          environment: DEV
+          ref: ${{ needs.determine-params.outputs.ref }}
+          description: 'Deployment of ${{ env.COMPONENT_NAME }} image ${{ needs.determine-params.outputs.image_tag }} to DEV'
+          auto-merge: false
+          payload: |
+            {
+              "image_tag": "${{ needs.determine-params.outputs.image_tag }}",
+              "component": "${{ env.COMPONENT_NAME }}",
+              "triggered_by": "${{ github.actor }}",
+              "timestamp": "${{ github.event.repository.updated_at }}",
+              "workflow_run_id": "${{ needs.determine-params.outputs.workflow_run_id }}"
+            }
+
+      - name: Update Deployment Status
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
+          state: "pending"
+          description: "Preparing to deploy"
+      
+      - name: Trigger Infrastructure Deployment
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.INFRA_REPO_TOKEN }}
+          repository: ${{ env.INFRA_REPO }}
+          event-type: new-image-dev
+          client-payload: |
+            {
+              "component": "${{ env.COMPONENT_NAME }}",
+              "image_tag": "${{ needs.determine-params.outputs.image_tag }}",
+              "source_repo": "${{ github.repository }}",
+              "source_deployment_id": "${{ steps.create_deployment.outputs.deployment_id }}"
+            }
+      
+      - name: Update Deployment Status
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
+          state: "in_progress"
+          description: "Deployment triggered in infrastructure repository"
+  
+  # Deploy to test environment
+  deploy-to-test:
+    name: Deploy to Test
+    needs: determine-params
+    if: needs.determine-params.outputs.environment == 'TEST'
+    runs-on: ubuntu-latest
+    environment:
+      name: TEST
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      
+      - name: Create GitHub Deployment
+        id: create_deployment
+        uses: chrnorm/deployment-action@v2
+        with:
+          token: ${{ github.token }}
+          environment: TEST
+          ref: ${{ needs.determine-params.outputs.ref }}
+          description: 'Deployment of ${{ env.COMPONENT_NAME }} image ${{ needs.determine-params.outputs.image_tag }} to TEST'
+          auto-merge: false
+          payload: |
+            {
+              "image_tag": "${{ needs.determine-params.outputs.image_tag }}",
+              "component": "${{ env.COMPONENT_NAME }}",
+              "triggered_by": "${{ github.actor }}",
+              "timestamp": "${{ github.event.repository.updated_at }}",
+              "workflow_run_id": "${{ needs.determine-params.outputs.workflow_run_id }}"
+            }
+
+      - name: Update Deployment Status
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
+          state: "pending"
+          description: "Preparing to deploy"
+      
+      - name: Trigger Infrastructure Deployment
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.INFRA_REPO_TOKEN }}
+          repository: ${{ env.INFRA_REPO }}
+          event-type: new-image-test
+          client-payload: |
+            {
+              "component": "${{ env.COMPONENT_NAME }}",
+              "image_tag": "${{ needs.determine-params.outputs.image_tag }}",
+              "source_repo": "${{ github.repository }}",
+              "source_deployment_id": "${{ steps.create_deployment.outputs.deployment_id }}"
+            }
+      
+      - name: Update Deployment Status
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
+          state: "in_progress"
+          description: "Deployment triggered in infrastructure repository"
+  
+  # Deploy to prod environment
+  deploy-to-prod:
+    name: Deploy to Production
+    needs: determine-params
+    if: needs.determine-params.outputs.environment == 'PROD'
+    runs-on: ubuntu-latest
+    environment:
+      name: PROD
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      
+      - name: Create GitHub Deployment
+        id: create_deployment
+        uses: chrnorm/deployment-action@v2
+        with:
+          token: ${{ github.token }}
+          environment: PROD
+          ref: ${{ needs.determine-params.outputs.ref }}
+          description: 'Deployment of ${{ env.COMPONENT_NAME }} image ${{ needs.determine-params.outputs.image_tag }} to PROD'
+          auto-merge: false
+          payload: |
+            {
+              "image_tag": "${{ needs.determine-params.outputs.image_tag }}",
+              "component": "${{ env.COMPONENT_NAME }}",
+              "triggered_by": "${{ github.actor }}",
+              "timestamp": "${{ github.event.repository.updated_at }}",
+              "workflow_run_id": "${{ needs.determine-params.outputs.workflow_run_id }}"
+            }
+
+      - name: Update Deployment Status
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
+          state: "pending"
+          description: "Preparing to deploy"
+      
+      - name: Trigger Infrastructure Deployment
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.INFRA_REPO_TOKEN }}
+          repository: ${{ env.INFRA_REPO }}
+          event-type: new-image-prod
+          client-payload: |
+            {
+              "component": "${{ env.COMPONENT_NAME }}",
+              "image_tag": "${{ needs.determine-params.outputs.image_tag }}",
+              "source_repo": "${{ github.repository }}",
+              "source_deployment_id": "${{ steps.create_deployment.outputs.deployment_id }}"
+            }
+      
+      - name: Update Deployment Status
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
+          state: "in_progress"
+          description: "Deployment triggered in infrastructure repository"


### PR DESCRIPTION
- Checkout dev in determine-params to read pom.xml when triggered from main
- Derive IMAGE_TAG from pom.xml; append -<shortsha> for DEV (no explicit version)
- Compute and output safe workflow_run_id and ref; use in deployments
- Lowercase repository_dispatch event types to match infra (new-image-dev/test/prod)