### PR TITLE
feat: implement Git tag-based versioning and streamline Docker builds

### DIFF
--- a/.github/workflows/push-to-dev.yml
+++ b/.github/workflows/push-to-dev.yml
@@ -37,11 +37,10 @@ jobs:
             echo "skip-build=false" >> $GITHUB_OUTPUT
           fi
   
-  # Build validator module on every push (except version bump commits)
+  # Build validator on every push (except version bump commits)
   build-validator:
     needs: [run-tests, check-version-bump]
     if: needs.check-version-bump.outputs.skip-build != 'true'
     uses: ./.github/workflows/reusable-docker-build.yml
     with:
       branch: dev
-      module: validator

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -20,19 +20,59 @@ permissions:
   packages: write
 
 jobs:
+  # Create Git tag for the release
+  create-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.determine-version.outputs.version }}
+      should_build: ${{ steps.determine-version.outputs.should_build }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      
+      - name: Determine version and create tag
+        id: determine-version
+        run: |
+          # Check if this is a release PR merge by looking at the PR title
+          PR_TITLE="${{ github.event.head_commit.message }}"
+          
+          if [[ "$PR_TITLE" =~ Release\ v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+            echo "Detected release version: $VERSION"
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "should_build=true" >> $GITHUB_OUTPUT
+            
+            # Create and push the tag
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "v$VERSION"
+            git push origin "v$VERSION"
+            
+            echo "Created and pushed tag v$VERSION"
+          else
+            echo "Not a release PR, skipping tag creation"
+            echo "should_build=false" >> $GITHUB_OUTPUT
+          fi
+  
   # Build Docker image for main branch
   build-validator:
+    needs: create-tag
+    if: needs.create-tag.outputs.should_build == 'true'
     uses: ./.github/workflows/reusable-docker-build.yml
     with:
       branch: main
-      module: validator
+      version: ${{ needs.create-tag.outputs.version }}
       
   # Sync dev with main after Docker build
   sync-dev:
     needs: build-validator
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -50,17 +90,32 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:${{ github.repository }}.git
       
-      - name: Recreate dev from main
+      - name: Merge main into dev
         run: |
-          # Get the current main branch
+          # Fetch latest branches
           git fetch origin main
+          git fetch origin dev
           
-          # Create a temporary branch from main
-          git checkout main
-          git checkout -b temp-dev
+          # Checkout dev
+          git checkout dev
           
-          # Force push this branch to dev
-          echo "Recreating dev from main..."
-          git push --force origin temp-dev:dev
+          # Get version that was just released
+          VERSION="${{ needs.create-tag.outputs.version }}"
+          echo "Merging release v$VERSION into dev..."
           
-          echo "Dev branch has been recreated from main"
+          # Merge main into dev (should be clean since release came from dev)
+          if git merge origin/main -m "Merge main into dev after release v$VERSION" --no-edit; then
+            echo "✅ Merge successful"
+          else
+            echo "⚠️ Merge conflicts detected. Manual resolution required."
+            echo "This is unexpected - release branch came from dev."
+            echo "Please check and resolve conflicts manually."
+            exit 1
+          fi
+          
+          # Push to dev
+          echo "Pushing merged dev branch..."
+          git push origin dev
+          
+          echo "✅ Dev branch synced with main after release v$VERSION"
+          echo "Note: Versions are managed via Git tags, no pom.xml changes needed"

--- a/.github/workflows/release-common-library.yml
+++ b/.github/workflows/release-common-library.yml
@@ -1,0 +1,130 @@
+name: Release Common Library
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 1.0.0, 1.1.0; leave empty for auto-patch-increment)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release-library:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17 with Maven
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+      
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: '3.9.6'
+
+      - name: Determine new version
+        id: version
+        working-directory: ismd-validator-common
+        run: |
+          CURRENT_VERSION=$(grep '<version>' pom.xml | head -1 | sed -E 's/.*<version>([^<]+)<.*/\1/')
+          echo "Current version: $CURRENT_VERSION"
+          
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            NEW_VERSION="${{ github.event.inputs.version }}"
+            echo "User provided version: $NEW_VERSION"
+          else
+            # Strip -SNAPSHOT first, then use as release version
+            # (next SNAPSHOT version will be incremented after release)
+            NEW_VERSION=$(echo $CURRENT_VERSION | sed 's/-SNAPSHOT//')
+            echo "Release version (stripped SNAPSHOT): $NEW_VERSION"
+          fi
+          
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update version in pom.xml
+        working-directory: ismd-validator-common
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.version }}"
+          sed -i "s/<version>[^<]*<\/version>/<version>$NEW_VERSION<\/version>/" pom.xml
+          echo "Updated pom.xml to version $NEW_VERSION"
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit version update
+        run: |
+          git add ismd-validator-common/pom.xml
+          git commit -m "Release common library v${{ steps.version.outputs.version }}"
+
+      - name: Create tag
+        run: |
+          git tag "common-v${{ steps.version.outputs.version }}"
+          git push origin "common-v${{ steps.version.outputs.version }}"
+
+      - name: Configure Maven settings for GitHub Packages
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<EOF
+          <settings>
+            <servers>
+              <server>
+                <id>github</id>
+                <username>${{ github.actor }}</username>
+                <password>${{ secrets.GITHUB_TOKEN }}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+
+      - name: Build and publish to GitHub Packages
+        working-directory: ismd-validator-common
+        run: |
+          mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bump to next SNAPSHOT version
+        working-directory: ismd-validator-common
+        run: |
+          CURRENT_VERSION="${{ steps.version.outputs.version }}"
+          NEXT_VERSION=$(echo $CURRENT_VERSION | awk -F. -v OFS=. '{$NF++;print}')-SNAPSHOT
+          sed -i "s/<version>[^<]*<\/version>/<version>$NEXT_VERSION<\/version>/" pom.xml
+          echo "Bumped pom.xml to next SNAPSHOT version: $NEXT_VERSION"
+
+      - name: Commit SNAPSHOT version
+        run: |
+          git add ismd-validator-common/pom.xml
+          git commit -m "Bump common library to next SNAPSHOT version"
+          git push origin ${{ github.ref_name }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "common-v${{ steps.version.outputs.version }}" \
+            --title "Common Library v${{ steps.version.outputs.version }}" \
+            --notes "Release of ismd-validator-common library v${{ steps.version.outputs.version }}
+            
+            **Published to GitHub Packages**
+            
+            To use this version in your project:
+            \`\`\`xml
+            <dependency>
+              <groupId>com.dia</groupId>
+              <artifactId>ismd-validator-common</artifactId>
+              <version>${{ steps.version.outputs.version }}</version>
+            </dependency>
+            \`\`\`"

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -11,12 +11,12 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: read
 
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest
     outputs:
-      current_version: ${{ steps.current-version.outputs.version }}
       main_version: ${{ steps.main-version.outputs.version }}
       new_version: ${{ steps.new-version.outputs.version }}
     steps:
@@ -35,25 +35,19 @@ jobs:
       - name: Fetch main branch
         run: git fetch origin main:main
 
-      - name: Get current version in dev
-        id: current-version
-        working-directory: ismd-backend-validator
-        run: echo "version=$(./mvnw help:evaluate -DforceStdout -q -Dexpression=project.version)" >> $GITHUB_OUTPUT
-
-      - name: Get version in main
+      - name: Get latest tag from main
         id: main-version
-        working-directory: ismd-backend-validator
         run: |
-          # Get main branch version by directly parsing the output of git show
-          ARTIFACT_ID=$(./mvnw help:evaluate -DforceStdout -q -Dexpression=project.artifactId)
-          MAIN_VERSION=$(git show main:ismd-backend-validator/pom.xml | grep -A 10 "<artifactId>$ARTIFACT_ID</artifactId>" | grep '<version>' | head -1 | sed -E 's/.*<version>([^<]+)<.*/\1/')
+          # Get latest version tag on main branch (only tags matching v[0-9]*)
+          git fetch origin main --tags
+          MAIN_TAG=$(git describe --tags --abbrev=0 --match "v[0-9]*" origin/main 2>/dev/null || echo "v0.0.0")
+          MAIN_VERSION=${MAIN_TAG#v}  # Strip 'v' prefix
           echo "version=$MAIN_VERSION" >> $GITHUB_OUTPUT
-          echo "Main branch version: $MAIN_VERSION"
+          echo "Latest version on main: $MAIN_VERSION"
 
       - name: Determine new version
         id: new-version
         run: |
-          CURRENT_VERSION="${{ steps.current-version.outputs.version }}"
           MAIN_VERSION="${{ steps.main-version.outputs.version }}"
           
           # Check if user provided a version
@@ -62,18 +56,12 @@ jobs:
             NEW_VERSION="${{ github.event.inputs.version }}"
             echo "User provided version: $NEW_VERSION"
           else
-            # Check if version in dev already differs from main
-            if [ "$CURRENT_VERSION" != "$MAIN_VERSION" ]; then
-              # Version already changed in code, use as is
-              NEW_VERSION="$CURRENT_VERSION"
-              echo "Using existing version from code: $NEW_VERSION"
-            else
-              # Auto-increment patch version
-              NEW_VERSION=$(echo $CURRENT_VERSION | awk -F. -v OFS=. '{$NF++;print}')
-              echo "Auto-incremented version: $NEW_VERSION"
-            fi
+            # Auto-increment patch version from main
+            NEW_VERSION=$(echo $MAIN_VERSION | awk -F. -v OFS=. '{$NF++;print}')
+            echo "Auto-incremented version: $NEW_VERSION"
           fi
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "New release version will be: $NEW_VERSION"
 
       - name: Create release branch
         id: create-branch
@@ -84,32 +72,14 @@ jobs:
           # Make sure we're on dev branch
           git checkout dev
           
-          # Create a new branch from dev
+          # Create a new branch from dev (no pom.xml changes needed!)
           git checkout -b $BRANCH_NAME
           
-          # Check if the version needs to be updated
-          CURRENT_VERSION="${{ steps.current-version.outputs.version }}"
-          NEW_VERSION="${{ steps.new-version.outputs.version }}"
+          # Configure git for later steps
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           
-          if [ "$CURRENT_VERSION" != "$NEW_VERSION" ]; then
-            echo "Updating version from $CURRENT_VERSION to $NEW_VERSION"
-            # Update version in root POM and all modules
-            ismd-backend-validator/mvnw versions:set -DnewVersion="$NEW_VERSION" -DgenerateBackupPoms=false -DprocessAllModules=true
-          
-            # Configure git
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-          
-            # Stage all POM files (root and modules)
-            git add ismd-validator-common/pom.xml ismd-backend-validator/pom.xml
-            git commit -m "Release v$NEW_VERSION"
-            echo "Version updated and committed"
-          else
-            echo "Version is already $CURRENT_VERSION, no update needed"
-            # Configure git anyway for later steps
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-          fi
+          echo "Created release branch $BRANCH_NAME from dev (no file changes needed)"
 
       - name: Install common library locally
         working-directory: ismd-backend-validator
@@ -140,13 +110,15 @@ jobs:
               --title "Release v${{ steps.new-version.outputs.version }}" \
               --body "# Release v${{ steps.new-version.outputs.version }}
           
-              This PR updates the version from v${{ steps.current-version.outputs.version }} to v${{ steps.new-version.outputs.version }} and merges changes from dev into main.
+              This PR merges changes from dev into main for release v${{ steps.new-version.outputs.version }}.
           
-              ## Changes included:
-              - Version bump to v${{ steps.new-version.outputs.version }}
-              - All changes from dev branch
+              ## What happens after merge:
+              1. Git tag \`v${{ steps.new-version.outputs.version }}\` will be created automatically
+              2. Docker images will be built with version \`${{ steps.new-version.outputs.version }}\`
+              3. Deployment to TEST environment will be triggered
+              4. Dev branch will be synced with main (clean merge, no file changes)
           
-              Once merged, this will trigger a Docker build with the new version." \
+              **Note:** Version is managed via Git tags, no pom.xml changes needed." \
               --base main \
               --head $BRANCH_NAME
           
@@ -159,13 +131,15 @@ jobs:
               --title "Release v${{ steps.new-version.outputs.version }}" \
               --body "# Release v${{ steps.new-version.outputs.version }}
           
-              This PR updates the version from v${{ steps.current-version.outputs.version }} to v${{ steps.new-version.outputs.version }} and merges changes from dev into main.
+              This PR merges changes from dev into main for release v${{ steps.new-version.outputs.version }}.
           
-              ## Changes included:
-              - Version bump to v${{ steps.new-version.outputs.version }}
-              - All changes from dev branch
+              ## What happens after merge:
+              1. Git tag \`v${{ steps.new-version.outputs.version }}\` will be created automatically
+              2. Docker images will be built with version \`${{ steps.new-version.outputs.version }}\`
+              3. Deployment to TEST environment will be triggered
+              4. Dev branch will be synced with main (clean merge, no file changes)
           
-              Once merged, this will trigger a Docker build with the new version.
+              **Note:** Version is managed via Git tags, no pom.xml changes needed.
           
               *Updated on $(date)*"
           

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -7,8 +7,8 @@ on:
         description: 'Branch name (main or dev)'
         required: true
         type: string
-      module:
-        description: 'Module to build (common, validator, or empty for all)'
+      version:
+        description: 'Version to use (from Git tag), leave empty to auto-detect'
         required: false
         type: string
         default: ''
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Fetch all history to get tags
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -47,72 +49,69 @@ jobs:
         id: version
         working-directory: ismd-backend-validator
         run: |
-          # Get the base version from Maven
-          if [ -z "${{ inputs.module }}" ] || [ "${{ inputs.module }}" = "root" ]; then
-            BASE_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          # If version provided via input, use it
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+            echo "Using provided version: $VERSION"
           else
-            BASE_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+            # Get base version from latest Git tag (only tags matching v[0-9]*)
+            BASE_VERSION=$(git describe --tags --abbrev=0 --match "v[0-9]*" 2>/dev/null | sed 's/^v//' || echo "0.0.1")
+            
+            if [ "${{ inputs.branch }}" = "main" ]; then
+              # For main, use tag version as-is
+              VERSION="$BASE_VERSION"
+              echo "Using version from Git tag: $VERSION"
+            else
+              # For dev, use tag version + SHA (tracks latest release)
+              VERSION="${BASE_VERSION}-$(git rev-parse --short HEAD)"
+              echo "Using dev version: $VERSION (based on latest tag $BASE_VERSION)"
+            fi
           fi
           
-          # For dev branches, create a version with Git SHA
-          if [ "${{ inputs.branch }}" != "main" ]; then
-            GIT_SHA=$(git rev-parse --short HEAD)
-            VERSION="${BASE_VERSION}-${GIT_SHA}"
-          else
-            VERSION="${BASE_VERSION}"
-            GIT_SHA=""
-          fi
+          GIT_SHA=$(git rev-parse --short HEAD)
           
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "base_version=$BASE_VERSION" >> $GITHUB_OUTPUT
           echo "git_sha=$GIT_SHA" >> $GITHUB_OUTPUT
           
-          echo "Using version: $VERSION (base: $BASE_VERSION, git: $GIT_SHA)"
+          echo "Final version: $VERSION (commit: $GIT_SHA)"
 
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         run: |
-          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          # Use the precomputed repository path
+          IMAGE_TAG="ghcr.io/${{ env.REPO_PATH }}:${{ steps.version.outputs.version }}"
+          LATEST_TAG="ghcr.io/${{ env.REPO_PATH }}:latest"
           
-          # Determine which modules to build
-          if [ -z "${{ inputs.module }}" ]; then
-            # Build only the validator module as common is just a library
-            MODULES=("validator")
-            MODULE_ARG="."  # Build everything
+          echo "Building validator with tags:"
+          echo "  - $IMAGE_TAG"
+          echo "  - $LATEST_TAG"
+          
+          # Determine if we should use local common library or GitHub Packages
+          if [ "${{ inputs.branch }}" = "main" ]; then
+            USE_LOCAL_COMMON="false"
+            echo "Production build: Will download common library from GitHub Packages"
           else
-            # Build specific module
-            MODULES=("${{ inputs.module }}")
-            MODULE_ARG="."
+            USE_LOCAL_COMMON="true"
+            echo "Dev build: Will use local common library"
           fi
           
-          # Build and push each module
-          for MODULE in "${MODULES[@]}"; do
-            echo "Building module: $MODULE"
-            
-            # Use the precomputed repository path
-            IMAGE_TAG="ghcr.io/${{ env.REPO_PATH }}:${{ steps.version.outputs.version }}"
-            LATEST_TAG="ghcr.io/${{ env.REPO_PATH }}:latest"
-            
-            echo "Building $MODULE with tags:"
-            echo "  - $IMAGE_TAG"
-            echo "  - $LATEST_TAG"
-            
-            # Build and push the image using Dockerfile in ismd-backend-validator with repo root as build context
-            docker build \
-              -f ismd-backend-validator/Dockerfile \
-              --target ${MODULE}-runtime \
-              --build-arg MODULE="${MODULE_ARG}" \
-              --build-arg MODULE_VERSION="${{ steps.version.outputs.version }}" \
-              --build-arg GIT_COMMIT="${{ steps.version.outputs.git_sha }}" \
-              -t $IMAGE_TAG \
-              ${LATEST_TAG:+-t $LATEST_TAG} \
-              .
-            
-            # Push the built image
-            docker push $IMAGE_TAG
-            
-            # Push both version and latest tags
-            docker push $LATEST_TAG
-            
-            echo "Successfully pushed $IMAGE_TAG"
-            echo "Successfully pushed $LATEST_TAG"
-          done
+          # Build and push the image using Dockerfile in ismd-backend-validator with repo root as build context
+          # Pass version to Maven via -Drevision build arg
+          docker build \
+            -f ismd-backend-validator/Dockerfile \
+            --target runtime \
+            --build-arg REVISION="${{ steps.version.outputs.version }}" \
+            --build-arg MODULE_VERSION="${{ steps.version.outputs.version }}" \
+            --build-arg GIT_COMMIT="${{ steps.version.outputs.git_sha }}" \
+            --build-arg USE_LOCAL_COMMON="$USE_LOCAL_COMMON" \
+            --build-arg GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
+            --build-arg GITHUB_ACTOR="${{ github.actor }}" \
+            -t $IMAGE_TAG \
+            -t $LATEST_TAG \
+            .
+          
+          # Push the built images
+          docker push $IMAGE_TAG
+          docker push $LATEST_TAG
+          
+          echo "Successfully pushed $IMAGE_TAG"
+          echo "Successfully pushed $LATEST_TAG"

--- a/ismd-backend-validator/Dockerfile
+++ b/ismd-backend-validator/Dockerfile
@@ -16,32 +16,38 @@ WORKDIR /app/ismd-backend-validator
 RUN chmod +x mvnw
 
 # Build arguments with defaults
-ARG MODULE=.
-ARG BUILD_ARGS="-DskipTests"
 ARG MODULE_VERSION=unknown
+ARG REVISION=0.0.1
+ARG GITHUB_TOKEN
+ARG GITHUB_ACTOR
+ARG USE_LOCAL_COMMON=true
 
-# Pre-install common library if present (temporary until published)
-RUN if [ -d ../ismd-validator-common ]; then \
+# Configure Maven to authenticate with GitHub Packages
+RUN if [ "$USE_LOCAL_COMMON" = "false" ]; then \
+      echo "Configuring Maven for GitHub Packages..."; \
+      mkdir -p ~/.m2 && \
+      echo '<settings><servers><server>' > ~/.m2/settings.xml && \
+      echo '<id>github</id>' >> ~/.m2/settings.xml && \
+      echo "<username>${GITHUB_ACTOR}</username>" >> ~/.m2/settings.xml && \
+      echo "<password>${GITHUB_TOKEN}</password>" >> ~/.m2/settings.xml && \
+      echo '</server></servers></settings>' >> ~/.m2/settings.xml; \
+    fi
+
+# Pre-install common library locally if present and USE_LOCAL_COMMON=true (dev builds)
+# Production builds will download from GitHub Packages instead
+RUN if [ "$USE_LOCAL_COMMON" = "true" ] && [ -d ../ismd-validator-common ]; then \
+      echo "Installing common library from local repo (dev build)..."; \
       ./mvnw -f ../ismd-validator-common/pom.xml -DskipTests install; \
-    fi
-
-# Build the specified module (or everything if not specified)
-RUN if [ "$MODULE" = "." ]; then \
-      ./mvnw clean install ${BUILD_ARGS}; \
     else \
-      ./mvnw clean install -pl ${MODULE} -am ${BUILD_ARGS}; \
+      echo "Common library will be downloaded from GitHub Packages (prod build)"; \
     fi
 
-# Create a default target that builds everything
-FROM builder AS all
-# This stage is just an alias for builder when building everything
+# Build the validator application
+# Pass -Drevision to set version from Git tag
+RUN ./mvnw clean install -Drevision=${REVISION} -DskipTests
 
-# Create a stage that does nothing, used as a default target
-FROM scratch AS default
-COPY --from=builder /app /app
-
-### Runtime stage for validator module
-FROM eclipse-temurin:17-jre-alpine AS validator-runtime
+### Runtime stage
+FROM eclipse-temurin:17-jre-alpine AS runtime
 WORKDIR /app
 
 # Get build arguments

--- a/ismd-backend-validator/pom.xml
+++ b/ismd-backend-validator/pom.xml
@@ -10,7 +10,7 @@
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.dia</groupId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <name>ismd-backend-validator</name>
     <description>ISMD Backend Validator</description>
 
@@ -18,7 +18,10 @@
 
     <properties>
         <java.version>17</java.version>
-        <ismd-validator-common.version>1.0-SNAPSHOT</ismd-validator-common.version>
+        <!-- Version from Git tag, overridden at build time (this default is not used) -->
+        <revision>0.0.1</revision>
+        <!-- Common library version - update explicitly when upgrading -->
+        <ismd-validator-common.version>1.0.0</ismd-validator-common.version>
     </properties>
 
     <dependencies>
@@ -111,6 +114,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <build>
         <plugins>

--- a/ismd-validator-common/pom.xml
+++ b/ismd-validator-common/pom.xml
@@ -6,13 +6,21 @@
 
     <groupId>com.dia</groupId>
     <artifactId>ismd-validator-common</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
 
     <properties>
         <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
+        </repository>
+    </distributionManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
**Versioning:**
- Versions now come from Git tags (e.g., `v1.0.0`) instead of package.json
- File stays at default `0.1.0` - overridden at build time
- No more editing package.json for releases

**Docker Builds:**
- Main: Clean version from tag (e.g., `1.0.0`)
- Dev: Tag + commit SHA (e.g., `1.0.0-abc1234`)

**Workflows:**
- Release creates PR without changing files
- Git tag auto-created after merge
- Dev syncs with main automatically (no version bumps)