### PR TITLE
versioning fix for releasing changes to common lib

### DIFF
--- a/.github/workflows/push-to-dev.yml
+++ b/.github/workflows/push-to-dev.yml
@@ -1,46 +1,64 @@
-name: Build Docker on Dev
+name: Build Dev Branch
 
 on:
   push:
     branches:
       - dev
-    paths-ignore:
-      - '**/README.md'
-      - '**/.gitignore'
-      - '**/*.md'
-      - '**/.gitkeep'
-      - '**/LICENSE'
-      - '**/target/**'
-      - '**/.idea/**'
-      - '**/*.iml'
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
-  run-tests:
-    uses: ./.github/workflows/reusable-test.yml
-    
-  check-version-bump:
+  check-common-lib-changes:
+    name: Check for Common Library Changes
     runs-on: ubuntu-latest
     outputs:
-      skip-build: ${{ steps.check-commit.outputs.skip-build }}
+      common_changed: ${{ steps.check.outputs.changed }}
+      needs_release: ${{ steps.check.outputs.needs_release }}
     steps:
-      - name: Check for version bump commit
-        id: check-commit
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+      
+      - name: Check if common library changed
+        id: check
         run: |
-          if [[ "${{ github.event.head_commit.message }}" =~ (Release v|Bump version) ]]; then
-            echo "skip-build=true" >> $GITHUB_OUTPUT
-            echo "Skipping build: Version bump detected"
+          # Check if common lib source files changed (exclude pom.xml version changes)
+          if git diff --name-only HEAD^ HEAD | grep "^ismd-validator-common/" | grep -v "pom.xml" | grep -q .; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "needs_release=true" >> $GITHUB_OUTPUT
+            echo "📦 Common library source files changed - will release new version"
+          elif git log -1 --pretty=%B | grep -q "Update validator to use common library"; then
+            # This is the auto-commit from release workflow, skip
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "needs_release=false" >> $GITHUB_OUTPUT
+            echo "⏭️  Skipping: This is a version update commit from release workflow"
           else
-            echo "skip-build=false" >> $GITHUB_OUTPUT
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "needs_release=false" >> $GITHUB_OUTPUT
+            echo "ℹ️  No common library source changes"
           fi
-  
-  # Build validator on every push (except version bump commits)
-  build-validator:
-    needs: [run-tests, check-version-bump]
-    if: needs.check-version-bump.outputs.skip-build != 'true'
+
+  release-common-lib:
+    name: Auto-Release Common Library
+    needs: check-common-lib-changes
+    if: needs.check-common-lib-changes.outputs.needs_release == 'true'
+    uses: ./.github/workflows/release-common-library.yml
+    secrets: inherit
+
+  test:
+    name: Run Tests
+    needs: [check-common-lib-changes, release-common-lib]
+    if: always() && !cancelled() && !failure()
+    uses: ./.github/workflows/reusable-test.yml
+    secrets: inherit
+
+  build-docker:
+    name: Build Docker Image
+    needs: test
     uses: ./.github/workflows/reusable-docker-build.yml
     with:
       branch: dev
+      push-to-registry: true
+    secrets: inherit

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -114,6 +114,28 @@ jobs:
           
           echo "Creating sync branch $SYNC_BRANCH from main..."
           git checkout -b $SYNC_BRANCH origin/main
+          
+          # Check if dev has newer common lib or validator code
+          DEV_COMMON=$(git show origin/dev:ismd-validator-common/pom.xml | grep '<version>' | head -1 | sed -E 's/.*<version>([^<]+)<.*/\1/')
+          MAIN_COMMON=$(grep '<version>' ismd-validator-common/pom.xml | head -1 | sed -E 's/.*<version>([^<]+)<.*/\1/')
+          
+          echo "Main has common library: $MAIN_COMMON"
+          echo "Dev has common library: $DEV_COMMON"
+          
+          # Only update if dev has newer version
+          if [ "$DEV_COMMON" != "$MAIN_COMMON" ]; then
+            echo "Dev has newer common library, updating..."
+            git checkout origin/dev -- ismd-validator-common
+            sed -i "s/<ismd-validator-common.version>.*<\/ismd-validator-common.version>/<ismd-validator-common.version>$DEV_COMMON<\/ismd-validator-common.version>/" ismd-backend-validator/pom.xml
+            git add ismd-validator-common ismd-backend-validator/pom.xml
+            git commit -m "Sync common library from dev after release
+          
+          - Updated common library to v$DEV_COMMON from dev
+          - Updated validator dependency to v$DEV_COMMON"
+          else
+            echo "Dev and main have same common library version, no update needed"
+          fi
+          
           git push origin $SYNC_BRANCH
           
           # Check if PR already exists
@@ -126,6 +148,14 @@ jobs:
               --body "# Sync Main → Dev after Release v$VERSION
               
               This PR syncs main back into dev after the v$VERSION release.
+              
+              ## Changes:
+              - Syncs validator code from main (released v$VERSION)
+              - Updates common library if dev has a newer released version
+              
+              ## Note:
+              Both branches use released versions only (no SNAPSHOT).
+              Dev may have newer common library versions from ongoing development.
               
               - If there are no conflicts, this can be merged automatically
               - If conflicts exist, they need to be resolved manually

--- a/.github/workflows/release-common-library.yml
+++ b/.github/workflows/release-common-library.yml
@@ -7,6 +7,12 @@ on:
         description: 'Version to release (e.g., 1.0.0, 1.1.0; leave empty for auto-patch-increment)'
         required: false
         type: string
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to release (leave empty for auto-patch-increment from SNAPSHOT)'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -118,23 +124,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Bump to next SNAPSHOT version
-        working-directory: ismd-validator-common
+      - name: Update validator to use released version
         run: |
-          CURRENT_VERSION="${{ steps.version.outputs.version }}"
-          NEXT_VERSION=$(echo $CURRENT_VERSION | awk -F. -v OFS=. '{$NF++;print}')-SNAPSHOT
-          sed -i "0,/<version>/s/<version>[^<]*<\/version>/<version>$NEXT_VERSION<\/version>/" pom.xml
-          echo "Bumped pom.xml to next SNAPSHOT version: $NEXT_VERSION"
-
-      - name: Commit SNAPSHOT version
-        run: |
-          git add ismd-validator-common/pom.xml
+          RELEASED_VERSION="${{ steps.version.outputs.version }}"
+          
+          # Update validator to use the released common lib version
+          sed -i "s/<ismd-validator-common.version>.*<\/ismd-validator-common.version>/<ismd-validator-common.version>$RELEASED_VERSION<\/ismd-validator-common.version>/" ismd-backend-validator/pom.xml
+          
+          git add ismd-backend-validator/pom.xml
+          
           # Only commit if there are changes
           if git diff --staged --quiet; then
-            echo "No SNAPSHOT version changes needed"
+            echo "No update needed - validator already uses v$RELEASED_VERSION"
           else
-            git commit -m "Bump common library to next SNAPSHOT version"
+            git commit -m "Update validator to use common library v$RELEASED_VERSION"
             git push origin ${{ github.ref_name }}
+            echo "✅ Updated validator to use common library v$RELEASED_VERSION"
           fi
 
       - name: Create GitHub Release

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -102,11 +102,54 @@ jobs:
           </settings>
           EOF
 
+      - name: Validate common library version
+        id: validate-common
+        run: |
+          # Dev branch has released versions only
+          COMMON_VERSION=$(grep '<version>' ismd-validator-common/pom.xml | head -1 | sed -E 's/.*<version>([^<]+)<.*/\1/')
+          VALIDATOR_COMMON_DEP=$(grep '<ismd-validator-common.version>' ismd-backend-validator/pom.xml | sed -E 's/.*<ismd-validator-common.version>([^<]+)<.*/\1/')
+          
+          echo "Common library version: $COMMON_VERSION"
+          echo "Validator dependency: $VALIDATOR_COMMON_DEP"
+          
+          # Verify it's a released version (no SNAPSHOT)
+          if [[ "$COMMON_VERSION" == *"-SNAPSHOT"* ]]; then
+            echo "❌ ERROR: Dev branch should not have SNAPSHOT versions"
+            echo "Please push to dev to trigger auto-release"
+            exit 1
+          fi
+          
+          # Verify the release tag exists
+          if ! git ls-remote --tags origin | grep -q "refs/tags/common-v${COMMON_VERSION}"; then
+            echo "❌ ERROR: Common library tag common-v$COMMON_VERSION not found"
+            echo "Publish common library before releasing validator"
+            exit 1
+          fi
+          
+          echo "✅ Using released common library: v$COMMON_VERSION"
+          echo "common_version=$COMMON_VERSION" >> $GITHUB_OUTPUT
+          
+          # Ensure validator dependency matches
+          if [ "$VALIDATOR_COMMON_DEP" != "$COMMON_VERSION" ]; then
+            echo "Updating validator to use $COMMON_VERSION..."
+            sed -i "s/<ismd-validator-common.version>.*<\/ismd-validator-common.version>/<ismd-validator-common.version>$COMMON_VERSION<\/ismd-validator-common.version>/" ismd-backend-validator/pom.xml
+          fi
+
       - name: Install common library locally
         working-directory: ismd-backend-validator
         run: ./mvnw -f ../ismd-validator-common/pom.xml -DskipTests install
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit release preparation
+        run: |
+          git add ismd-validator-common ismd-backend-validator/pom.xml
+          git commit -m "Prepare release v${{ steps.new-version.outputs.version }}
+          
+          - Use common library v${{ steps.prepare-release.outputs.common_version }} (released)
+          - Common library code from tag common-v${{ steps.prepare-release.outputs.common_version }}
+          - Updated validator dependency to released version"
+          echo "✅ Committed release preparation"
 
       - name: Run tests
         working-directory: ismd-backend-validator

--- a/ismd-backend-validator/pom.xml
+++ b/ismd-backend-validator/pom.xml
@@ -22,6 +22,8 @@
         <revision>0.0.1</revision>
         <!-- Common library version - update explicitly when upgrading -->
         <ismd-validator-common.version>1.0.0</ismd-validator-common.version>
+        <!-- GitHub repository for common library packages -->
+        <github.repository>datagov-cz/ismd-validator-common</github.repository>
     </properties>
 
     <dependencies>
@@ -119,7 +121,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
+            <url>https://maven.pkg.github.com/${github.repository}</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/ismd-validator-common/pom.xml
+++ b/ismd-validator-common/pom.xml
@@ -6,19 +6,21 @@
 
     <groupId>com.dia</groupId>
     <artifactId>ismd-validator-common</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.0</version>
 
     <properties>
         <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <!-- GitHub repository for publishing packages -->
+        <github.repository>datagov-cz/ismd-validator-common</github.repository>
     </properties>
 
     <distributionManagement>
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
+            <url>https://maven.pkg.github.com/${github.repository}</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
common lib version now increments and releases a package via push to dev, release to main uses the version specified in dev at the point of release