### PR TITLE
feat: add docker-compose for local dev stack

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,21 @@
+# ==============================================
+# ISMD Validator Backend - Build Override
+# ==============================================
+# Use with the base file to build from local source instead of pulling:
+#   docker compose -f docker-compose.yml -f docker-compose.build.yml up --build
+#
+# Requires GITHUB_TOKEN + GITHUB_ACTOR for Maven access to GitHub Packages
+# (only needed when USE_LOCAL_COMMON=false, kept for parity with prod build).
+# ==============================================
+
+services:
+  ismd-validator-backend:
+    image: ismd-validator-backend:local
+    pull_policy: never
+    build:
+      context: .
+      dockerfile: ismd-backend-validator/Dockerfile
+      args:
+        GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+        GITHUB_ACTOR: ${GITHUB_ACTOR:-}
+        USE_LOCAL_COMMON: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+# ==============================================
+# ISMD Validator Backend - Docker Compose
+# ==============================================
+# Standalone use:
+#   docker compose up                                      # pull dev image from GHCR
+#   docker compose -f docker-compose.yml \
+#                  -f docker-compose.build.yml up --build  # build from local source
+#
+# Aggregated use:
+#   See ../infrastructure/docker-compose.yml
+#
+# Port mapping: host 8082 -> container 8080 (avoids conflict with Keycloak on 8080)
+# ==============================================
+
+services:
+  ismd-validator-backend:
+    image: ${VALIDATOR_BACKEND_IMAGE:-ghcr.io/datagov-cz/ismd-validator-backend-dev:latest}
+    container_name: ismd-validator-backend
+    pull_policy: ${VALIDATOR_BACKEND_PULL_POLICY:-missing}
+    environment:
+      - SPRING_PROFILES_ACTIVE=${VALIDATOR_PROFILE:-localhost}
+      - CORS_ALLOWED_ORIGINS=${VALIDATOR_CORS_ORIGINS:-http://localhost:3000,http://localhost:3001}
+    ports:
+      - "8082:8080"
+    networks:
+      - ismd-network
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+networks:
+  ismd-network:
+    name: ismd-network
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@
 #                  -f docker-compose.build.yml up --build  # build from local source
 #
 # Aggregated use:
-#   See ../infrastructure/docker-compose.yml
+#   See ../ismd-infrastructure/docker-compose.yml
 #
 # Port mapping: host 8082 -> container 8080 (avoids conflict with Keycloak on 8080)
 # ==============================================


### PR DESCRIPTION
Validator backend exposed on port 8082 to avoid collision with Keycloak. Supports pulling pre-built dev images or building from local source.