### PR TITLE
chore: update workflows in main

### DIFF
--- a/.github/workflows/code-quality-report.yml
+++ b/.github/workflows/code-quality-report.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -32,7 +32,7 @@ jobs:
           server-password: GITHUB_TOKEN
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-quality-${{ hashFiles('**/pom.xml', 'ismd-validator-common/src/**') }}
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload quality reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: backend-quality-report-${{ github.run_id }}
           path: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,69 @@
+name: CodeQL
+
+# GitHub-native SAST for Java. CodeQL needs to observe a real Maven build to
+# build its database, so we replicate the same prerequisites as reusable-test.yml
+# (JDK 17, common library install via mvnw).
+# Findings appear in Security -> Code scanning.
+
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+  schedule:
+    - cron: '0 6 * * 1'   # Weekly Monday 06:00 UTC
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+  packages: read
+
+jobs:
+  analyze:
+    name: Analyze (java)
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_ACTOR: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Cache Maven packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-codeql-${{ hashFiles('**/pom.xml', 'ismd-validator-common/src/**') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: java-kotlin
+          queries: security-extended
+          build-mode: manual
+
+      - name: Install common library
+        working-directory: ismd-backend-validator
+        run: ./mvnw -f ../ismd-validator-common/pom.xml -DskipTests install
+
+      - name: Build validator backend
+        working-directory: ismd-backend-validator
+        run: ./mvnw -DskipTests clean package
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:java-kotlin"

--- a/.github/workflows/push-to-dev.yml
+++ b/.github/workflows/push-to-dev.yml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       needs_release: ${{ steps.check.outputs.needs_release }}
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
       

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -30,7 +30,7 @@ jobs:
       should_build: ${{ steps.determine-version.outputs.should_build }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       
@@ -85,7 +85,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Get full history
       

--- a/.github/workflows/release-common-library.yml
+++ b/.github/workflows/release-common-library.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -24,7 +24,7 @@ jobs:
       new_version: ${{ steps.new-version.outputs.version }}
     steps:
       - name: Checkout dev branch
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
         with:
           ref: dev
           fetch-depth: 0

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -22,19 +22,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history to get tags
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with: 
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up repository path
         id: repo-setup

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -25,7 +25,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -37,7 +37,7 @@ jobs:
           server-password: GITHUB_TOKEN
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', 'ismd-validator-common/src/**') }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload JaCoCo coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: backend-jacoco-report-${{ github.run_id }}
           path: ismd-backend-validator/target/site/jacoco

--- a/.github/workflows/trigger-deployment.yml
+++ b/.github/workflows/trigger-deployment.yml
@@ -48,7 +48,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history including tags
       
@@ -186,7 +186,7 @@ jobs:
     needs: determine-params
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -227,7 +227,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
       
       - name: Create GitHub Deployment
         id: create_deployment
@@ -305,7 +305,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
       
       - name: Create GitHub Deployment
         id: create_deployment
@@ -382,7 +382,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
       
       - name: Create GitHub Deployment
         id: create_deployment

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,65 @@
+name: Trivy Image Scan
+
+# Calls the reusable Trivy scanner owned by infrastructure repo.
+# Findings appear in this repo's Security -> Code scanning tab.
+#
+# Image taxonomy (see reusable-docker-build.yml):
+#   dev branch  -> ghcr.io/datagov-cz/ismd-validator-backend-dev:latest    (deployed to dev env)
+#   main branch -> ghcr.io/datagov-cz/ismd-validator-backend:latest        (deployed to test + prod)
+#
+# Triggers:
+#   * After "Build Docker on Dev"  completes -> scan dev image
+#   * After "Build Docker on Main" completes -> scan main image
+#   * Weekly Monday 07:00 UTC               -> scan BOTH (CVE-feed drift)
+#   * Manual dispatch                        -> pick dev/main/both
+
+on:
+  workflow_run:
+    workflows: ["Build Docker on Dev", "Build Docker on Main"]
+    types: [completed]
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+    inputs:
+      image_variant:
+        description: 'Which image(s) to scan'
+        required: true
+        type: choice
+        options: [dev, main, both]
+        default: both
+      soft_fail:
+        description: 'Non-blocking: workflow stays green even if findings exist (default). Uncheck to make scan blocking for this run.'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: read
+  security-events: write
+
+jobs:
+  scan-dev:
+    name: Scan dev image
+    if: |
+      (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Build Docker on Dev' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && (inputs.image_variant == 'dev' || inputs.image_variant == 'both'))
+    uses: datagov-cz/ismd-infrastructure/.github/workflows/trivy-reusable.yml@dev
+    with:
+      image_ref: ghcr.io/datagov-cz/ismd-validator-backend-dev:latest
+      # Default non-blocking. Only a manual dispatch with soft_fail=false flips it.
+      soft_fail: ${{ !(github.event_name == 'workflow_dispatch' && inputs.soft_fail == false) }}
+    secrets: inherit
+
+  scan-main:
+    name: Scan main image
+    if: |
+      (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Build Docker on Main' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && (inputs.image_variant == 'main' || inputs.image_variant == 'both'))
+    uses: datagov-cz/ismd-infrastructure/.github/workflows/trivy-reusable.yml@dev
+    with:
+      image_ref: ghcr.io/datagov-cz/ismd-validator-backend:latest
+      soft_fail: ${{ !(github.event_name == 'workflow_dispatch' && inputs.soft_fail == false) }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
Promotes `.github/` workflow changes from `dev` to `main`. App code on `dev` stays on `dev`.

## What's included
- **New**: `codeql.yml`, `trivy.yml` (security scans)
- **Action version + pin alignment**: `code-quality-report.yml`, `push-to-dev.yml`, `push-to-main.yml`, `release-common-library.yml`, `release-version.yml`, `reusable-docker-build.yml`, `reusable-test.yml`, `trigger-deployment.yml`