### PR TITLE
fix: normalize mvnw line endings to prevent CRLF build failures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
-/mvnw text eol=lf
+* text=auto eol=lf
+mvnw text eol=lf
+*.sh text eol=lf
 *.cmd text eol=crlf
+*.bat text eol=crlf

--- a/ismd-backend-validator/Dockerfile
+++ b/ismd-backend-validator/Dockerfile
@@ -12,8 +12,8 @@ COPY ismd-validator-common/ ./ismd-validator-common
 # Switch to validator module root (contains mvnw)
 WORKDIR /app/ismd-backend-validator
 
-# Make mvnw executable
-RUN chmod +x mvnw
+# Normalize line endings (handle CRLF from Windows checkouts) and make mvnw executable
+RUN sed -i 's/\r$//' mvnw && chmod +x mvnw
 
 # Build arguments with defaults
 ARG MODULE_VERSION=unknown


### PR DESCRIPTION
Windows checkouts with core.autocrlf=true convert mvnw to CRLF, which makes the shebang resolve to `/bin/sh\r` inside Alpine and fails the Docker build with the misleading `./mvnw: not found`.

- Dockerfile: strip CR from mvnw before chmod so the build is robust regardless of the host's git config.
- .gitattributes: enforce LF on mvnw and shell scripts (previous `/mvnw` rule only matched repo root, not the actual file in ismd-backend-validator/), keep CRLF on .cmd/.bat.