### PR TITLE
Feat/iri parser and nkd sparql endpoint

### DIFF
--- a/ismd-backend-validator/src/main/java/com/dia/conversion/transformer/OntologyResourceBuilder.java
+++ b/ismd-backend-validator/src/main/java/com/dia/conversion/transformer/OntologyResourceBuilder.java
@@ -884,6 +884,9 @@ public class OntologyResourceBuilder {
         if (checkIfXsdType(trimmedDataType, rangeProperty, propertyResource)) {
             return;
         }
+        if (checkIfRdfsType(trimmedDataType, rangeProperty, propertyResource)) {
+            return;
+        }
         if (checkIfFullXsdUri(trimmedDataType, rangeProperty, propertyResource)) {
             return;
         }
@@ -916,6 +919,20 @@ public class OntologyResourceBuilder {
                 log.warn("Invalid XSD type '{}' - falling back to rdfs:Literal", trimmedDataType);
                 propertyResource.addProperty(rangeProperty, ontModel.createResource(DataTypeConstants.RDFS_LITERAL));
             }
+            return true;
+        }
+        return false;
+    }
+
+    private boolean checkIfRdfsType(String trimmedDataType, Property rangeProperty, Resource propertyResource) {
+        if (trimmedDataType.startsWith("rdfs:")) {
+            // Expand the rdfs: CURIE to its full IRI rather than letting checkIfValidUri keep it
+            // verbatim. Jena's IRI parser (used by isUri) accepts "rdfs:Literal" as an absolute
+            // IRI, so without this the raw CURIE would be emitted as the range resource.
+            String localName = trimmedDataType.substring("rdfs:".length());
+            propertyResource.addProperty(rangeProperty,
+                    ontModel.createResource(ExportConstants.Json.RDFS_NS + localName));
+            log.debug("Expanded rdfs CURIE range type: {}", trimmedDataType);
             return true;
         }
         return false;

--- a/ismd-backend-validator/src/main/resources/application-localhost.properties
+++ b/ismd-backend-validator/src/main/resources/application-localhost.properties
@@ -9,7 +9,7 @@ logging.level.com.dia.exporter.TurtleExporter=DEBUG
 
 
 # TEST SPARQL NKD endpoint
-validation.global.sparql-endpoint=https://oha02.dia.gov.cz/vsparql
+validation.global.sparql-endpoint=https://data.gov.cz/slovn%C3%ADky/sparql
 
 # Multipart file upload configuration
 spring.servlet.multipart.max-file-size=${MAX_UPLOAD_FILE_SIZE:10MB}

--- a/ismd-validator-common/src/main/java/com/dia/utility/DataTypeConverter.java
+++ b/ismd-validator-common/src/main/java/com/dia/utility/DataTypeConverter.java
@@ -251,10 +251,17 @@ public class DataTypeConverter {
         try {
             // Use Jena's IRI parser rather than java.net.URI: IRIs in the vocabulary
             // routinely contain non-ASCII characters (e.g. https://slovník.gov.cz/...),
-            // which java.net.URI rejects with a URISyntaxException. isAbsolute() requires
-            // a scheme and authority, so bare names ("example.com", "not-a-uri") and
-            // scheme-only values ("https://", which throws) are still rejected.
-            return org.apache.jena.irix.IRIx.create(value.trim()).isAbsolute();
+            // which java.net.URI rejects with a URISyntaxException.
+            //
+            // Accept any IRI that carries a scheme and is not a relative reference. We
+            // deliberately do NOT use isAbsolute(): per RFC 3987 an "absolute" IRI excludes
+            // a fragment, so isAbsolute() returns false for fragment IRIs such as
+            // "http://www.w3.org/2000/01/rdf-schema#Literal" — which are legitimate range
+            // and reference values here. Requiring scheme + !relative still rejects bare
+            // names ("example.com", "not-a-uri") and scheme-only values ("https://", which
+            // throws).
+            org.apache.jena.irix.IRIx iri = org.apache.jena.irix.IRIx.create(value.trim());
+            return iri.scheme() != null && !iri.isRelative();
         } catch (Exception e) {
             return false;
         }

--- a/ismd-validator-common/src/main/java/com/dia/utility/DataTypeConverter.java
+++ b/ismd-validator-common/src/main/java/com/dia/utility/DataTypeConverter.java
@@ -245,9 +245,16 @@ public class DataTypeConverter {
     }
 
     public static boolean isUri(String value) {
+        if (value == null || value.isBlank()) {
+            return false;
+        }
         try {
-            java.net.URI uri = new java.net.URI(value);
-            return uri.getScheme() != null && uri.getHost() != null;
+            // Use Jena's IRI parser rather than java.net.URI: IRIs in the vocabulary
+            // routinely contain non-ASCII characters (e.g. https://slovník.gov.cz/...),
+            // which java.net.URI rejects with a URISyntaxException. isAbsolute() requires
+            // a scheme and authority, so bare names ("example.com", "not-a-uri") and
+            // scheme-only values ("https://", which throws) are still rejected.
+            return org.apache.jena.irix.IRIx.create(value.trim()).isAbsolute();
         } catch (Exception e) {
             return false;
         }

--- a/ismd-validator-common/src/test/java/com/dia/utility/DataTypeConverterUnitTest.java
+++ b/ismd-validator-common/src/test/java/com/dia/utility/DataTypeConverterUnitTest.java
@@ -258,6 +258,17 @@ class DataTypeConverterUnitTest {
         assertFalse(DataTypeConverter.isUri("   "));
     }
 
+    @Test
+    void testIsUri_withFragmentIris() {
+        // Fragment IRIs are valid URIs here (used as range/reference values). Jena's
+        // isAbsolute() returns false for these because RFC 3987 absolute IRIs exclude a
+        // fragment, so isUri must not rely on isAbsolute().
+        assertTrue(DataTypeConverter.isUri("http://www.w3.org/2000/01/rdf-schema#Literal"));
+        assertTrue(DataTypeConverter.isUri("http://www.w3.org/2001/XMLSchema#string"));
+        assertTrue(DataTypeConverter.isUri(
+                "https://slovník.gov.cz/příkladový-slovník/pojem/text-p#fragment"));
+    }
+
     // Date tests
     @Test
     void testIsDate_withValidDates() {

--- a/ismd-validator-common/src/test/java/com/dia/utility/DataTypeConverterUnitTest.java
+++ b/ismd-validator-common/src/test/java/com/dia/utility/DataTypeConverterUnitTest.java
@@ -245,6 +245,19 @@ class DataTypeConverterUnitTest {
         assertFalse(DataTypeConverter.isUri("https://")); // no host
     }
 
+    @Test
+    void testIsUri_withNonAsciiIris() {
+        // IRIs with non-ASCII characters (Czech diacritics) are valid and must be
+        // recognised as-is, not slugified. java.net.URI rejected these.
+        assertTrue(DataTypeConverter.isUri(
+                "https://slovník.gov.cz/a124-datový-slovník-iskn/pojem/právní-vztah"));
+        assertTrue(DataTypeConverter.isUri(
+                "https://slovník.gov.cz/datový/číselníky/pojem/položka-číselníku"));
+
+        assertFalse(DataTypeConverter.isUri(null));
+        assertFalse(DataTypeConverter.isUri("   "));
+    }
+
     // Date tests
     @Test
     void testIsDate_withValidDates() {


### PR DESCRIPTION
Summary

DataTypeConverter IRI validation switched to Jena IRI parser - handles diacritics in IRI better
application.properties still had the pre-deployed NKD SPARQL endpoint, switched to deployed one