### PR TITLE
ci: fix Trivy dev-scan trigger and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+# Dependabot — watches Maven dependencies across the two backend modules.
+# The validator-common library is consumed from GitHub Packages, so Dependabot
+# needs an authenticated registry to read its metadata.
+version: 2
+registries:
+  validator-packages:
+    type: maven-repository
+    url: https://maven.pkg.github.com/datagov-cz/ismd-validator-backend
+    username: x-access-token
+    password: ${{ secrets.PACKAGES_READ_TOKEN }}
+
+updates:
+  - package-ecosystem: maven
+    directories:
+      - /ismd-backend-validator
+      - /ismd-validator-common
+    schedule:
+      interval: weekly
+    # Scheduled version-update PRs open against dev for review before reaching main.
+    # NOTE: security updates always target the default branch and ignore this.
+    target-branch: dev
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+    registries:
+      - validator-packages
+    # One grouped PR per run instead of a separate PR per dependency per module.
+    groups:
+      maven-dependencies:
+        patterns:
+          - "*"
+
+  # Watches action versions pinned in .github/workflows/ (actions/checkout, etc.).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: dev
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -8,14 +8,14 @@ name: Trivy Image Scan
 #   main branch -> ghcr.io/datagov-cz/ismd-validator-backend:latest        (deployed to test + prod)
 #
 # Triggers:
-#   * After "Build Docker on Dev"  completes -> scan dev image
+#   * After "Build Dev Branch"  completes -> scan dev image
 #   * After "Build Docker on Main" completes -> scan main image
 #   * Weekly Monday 07:00 UTC               -> scan BOTH (CVE-feed drift)
 #   * Manual dispatch                        -> pick dev/main/both
 
 on:
   workflow_run:
-    workflows: ["Build Docker on Dev", "Build Docker on Main"]
+    workflows: ["Build Dev Branch", "Build Docker on Main"]
     types: [completed]
   schedule:
     - cron: '0 7 * * 1'
@@ -42,7 +42,7 @@ jobs:
   scan-dev:
     name: Scan dev image
     if: |
-      (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Build Docker on Dev' && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Build Dev Branch' && github.event.workflow_run.conclusion == 'success') ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && (inputs.image_variant == 'dev' || inputs.image_variant == 'both'))
     uses: datagov-cz/ismd-infrastructure/.github/workflows/trivy-reusable.yml@dev


### PR DESCRIPTION
### Fix Trivy dev image scan trigger
The `trivy.yml` `workflow_run` trigger referenced a workflow named
`"Build Docker on Dev"`, but the actual workflow is named `"Build Dev Branch"`.
The name mismatch meant the dev image scan never fired after a dev build.
Corrected the name in both the `workflow_run.workflows` list and the
`scan-dev` job condition.

### Add Dependabot config targeting dev
New `.github/dependabot.yml`:
- **maven** across both modules (`ismd-backend-validator`, `ismd-validator-common`),
  using the GitHub Packages registry (`PACKAGES_READ_TOKEN`) to resolve the
  private `ismd-validator-common` dependency.
- **github-actions** to keep workflow action versions current.
- Weekly, grouped into one PR per ecosystem, with version-update PRs opening
  against `dev`. Security updates still target the default branch.

## Notes
- Requires the `PACKAGES_READ_TOKEN` secret in this repo (added).
- Dependabot only activates once the config reaches the default branch (main),
  via the usual dev → main promotion.